### PR TITLE
adding vm_id_number variables to pkr examples and allowing static vm_id

### DIFF
--- a/builds/linux/centos/10-stream/linux-centos-stream.pkr.hcl
+++ b/builds/linux/centos/10-stream/linux-centos-stream.pkr.hcl
@@ -121,6 +121,7 @@ source "proxmox-iso" "linux-centos-stream" {
   memory          = "${var.vm_mem_size}"
   os              = "${var.vm_os_type}"
   scsi_controller = "${var.vm_disk_controller_type}"
+  vm_id           = "${var.vm_id_number}"
 
   disks {
     disk_size     = "${var.vm_disk_size}"
@@ -228,6 +229,7 @@ build {
       vm_mem_size              = "${var.vm_mem_size}"
       vm_network_card_model    = "${var.vm_network_card_model}"
       vm_cloudinit             = "${var.vm_cloudinit}"
+      vm_id                    = "${var.vm_id_number}"
     }
   }
 }

--- a/builds/linux/centos/10-stream/linux-centos-stream.pkrvars.hcl.example
+++ b/builds/linux/centos/10-stream/linux-centos-stream.pkrvars.hcl.example
@@ -26,6 +26,7 @@ vm_disk_size            = "32G"
 vm_disk_format          = "raw"
 vm_disk_controller_type = "virtio-scsi-pci"
 vm_network_card_model   = "virtio"
+vm_id                   = "10013"
 
 // Removable Media Settings
 iso_path     = "iso"

--- a/builds/linux/centos/10-stream/variables.pkr.hcl
+++ b/builds/linux/centos/10-stream/variables.pkr.hcl
@@ -88,6 +88,12 @@ variable "vm_bios" {
   }
 }
 
+variable "vm_id_number" {
+  type        = string
+  description = "standardized template number."
+  default = "10013"
+}  
+
 variable "vm_firmware_path" {
   type        = string
   description = "The firmware file to be used. Needed for EFI"

--- a/builds/linux/centos/9-stream/linux-centos-stream.pkr.hcl
+++ b/builds/linux/centos/9-stream/linux-centos-stream.pkr.hcl
@@ -121,6 +121,7 @@ source "proxmox-iso" "linux-centos-stream" {
   memory          = "${var.vm_mem_size}"
   os              = "${var.vm_os_type}"
   scsi_controller = "${var.vm_disk_controller_type}"
+  vm_id           = "${var.vm_id_number}"
 
   disks {
     disk_size     = "${var.vm_disk_size}"
@@ -228,6 +229,7 @@ build {
       vm_mem_size              = "${var.vm_mem_size}"
       vm_network_card_model    = "${var.vm_network_card_model}"
       vm_cloudinit             = "${var.vm_cloudinit}"
+      vm_id                    = "${var.vm_id_number}"
     }
   }
 }

--- a/builds/linux/centos/9-stream/linux-centos-stream.pkrvars.hcl.example
+++ b/builds/linux/centos/9-stream/linux-centos-stream.pkrvars.hcl.example
@@ -26,6 +26,7 @@ vm_disk_size            = "32G"
 vm_disk_format          = "raw"
 vm_disk_controller_type = "virtio-scsi-pci"
 vm_network_card_model   = "virtio"
+vm_id                   = "10014"
 
 // Removable Media Settings
 iso_path     = "iso"

--- a/builds/linux/centos/9-stream/variables.pkr.hcl
+++ b/builds/linux/centos/9-stream/variables.pkr.hcl
@@ -88,6 +88,12 @@ variable "vm_bios" {
   }
 }
 
+variable "vm_id_number" {
+  type        = string
+  description = "standardized template number."
+  default = "10014"
+}  
+
 variable "vm_firmware_path" {
   type        = string
   description = "The firmware file to be used. Needed for EFI"

--- a/builds/linux/debian/11/linux-debian.pkr.hcl
+++ b/builds/linux/debian/11/linux-debian.pkr.hcl
@@ -144,6 +144,7 @@ source "proxmox-iso" "debian" {
   memory          = "${var.vm_mem_size}"
   os              = "${var.vm_os_type}"
   scsi_controller = "${var.vm_disk_controller_type}"
+  vm_id           = "${var.vm_id_number}"
 
   disks {
     disk_size     = "${var.vm_disk_size}"
@@ -251,6 +252,7 @@ build {
       vm_mem_size              = "${var.vm_mem_size}"
       vm_network_card_model    = "${var.vm_network_card_model}"
       vm_cloudinit             = "${var.vm_cloudinit}"
+      vm_id                    = "${var.vm_id_number}"
     }
   }
 }

--- a/builds/linux/debian/11/linux-debian.pkrvars.hcl.example
+++ b/builds/linux/debian/11/linux-debian.pkrvars.hcl.example
@@ -26,6 +26,7 @@ vm_disk_size            = "32G"
 vm_disk_format          = "raw"
 vm_disk_controller_type = "virtio-scsi-pci"
 vm_network_card_model   = "virtio"
+vm_id                   = "10012"
 
 // Removable Media Settings
 iso_path     = "iso"

--- a/builds/linux/debian/11/variables.pkr.hcl
+++ b/builds/linux/debian/11/variables.pkr.hcl
@@ -88,6 +88,12 @@ variable "vm_bios" {
   }
 }
 
+variable "vm_id_number" {
+  type        = string
+  description = "standardized template number."
+  default = "10012"
+} 
+
 variable "vm_firmware_path" {
   type        = string
   description = "The firmware file to be used. Needed for EFI"

--- a/builds/linux/debian/12/linux-debian.pkr.hcl
+++ b/builds/linux/debian/12/linux-debian.pkr.hcl
@@ -143,6 +143,8 @@ source "proxmox-iso" "debian" {
   memory          = "${var.vm_mem_size}"
   os              = "${var.vm_os_type}"
   scsi_controller = "${var.vm_disk_controller_type}"
+  vm_id           = "${var.vm_id_number}"
+
 
   disks {
     disk_size     = "${var.vm_disk_size}"
@@ -250,6 +252,7 @@ build {
       vm_mem_size              = "${var.vm_mem_size}"
       vm_network_card_model    = "${var.vm_network_card_model}"
       vm_cloudinit             = "${var.vm_cloudinit}"
+      vm_id                    = "${var.vm_id_number}"
     }
   }
 }

--- a/builds/linux/debian/12/linux-debian.pkrvars.hcl.example
+++ b/builds/linux/debian/12/linux-debian.pkrvars.hcl.example
@@ -26,6 +26,7 @@ vm_disk_size            = "32G"
 vm_disk_format          = "raw"
 vm_disk_controller_type = "virtio-scsi-pci"
 vm_network_card_model   = "virtio"
+vm_id                   = "10011"
 
 // Removable Media Settings
 iso_path     = "iso"

--- a/builds/linux/debian/12/variables.pkr.hcl
+++ b/builds/linux/debian/12/variables.pkr.hcl
@@ -88,6 +88,12 @@ variable "vm_bios" {
   }
 }
 
+variable "vm_id_number" {
+  type        = string
+  description = "standardized template number."
+  default = "10011"
+}  
+
 variable "vm_firmware_path" {
   type        = string
   description = "The firmware file to be used. Needed for EFI"

--- a/builds/linux/opensuse/leap-15-5/linux-opensuse-leap.pkr.hcl
+++ b/builds/linux/opensuse/leap-15-5/linux-opensuse-leap.pkr.hcl
@@ -126,6 +126,7 @@ source "proxmox-iso" "linux-opensuse-leap" {
   memory          = "${var.vm_mem_size}"
   os              = "${var.vm_os_type}"
   scsi_controller = "${var.vm_disk_controller_type}"
+  vm_id           = var.vm_id_number
 
   disks {
     disk_size     = "${var.vm_disk_size}"

--- a/builds/linux/opensuse/leap-15-5/linux-opensuse-leap.pkrvars.hcl.example
+++ b/builds/linux/opensuse/leap-15-5/linux-opensuse-leap.pkrvars.hcl.example
@@ -26,6 +26,7 @@ vm_disk_size            = "32G"
 vm_disk_format          = "raw"
 vm_disk_controller_type = "virtio-scsi-pci"
 vm_network_card_model   = "virtio"
+vm_id                   = "10010"
 
 // Removable Media Settings
 iso_path     = "iso"

--- a/builds/linux/opensuse/leap-15-5/variables.pkr.hcl
+++ b/builds/linux/opensuse/leap-15-5/variables.pkr.hcl
@@ -88,6 +88,12 @@ variable "vm_bios" {
   }
 }
 
+variable "vm_id_number" {
+  type        = string
+  description = "standardized template number."
+  default = "10010"
+}  
+
 variable "vm_firmware_path" {
   type        = string
   description = "The firmware file to be used. Needed for EFI"

--- a/builds/linux/opensuse/leap-15-6/linux-opensuse-leap.pkr.hcl
+++ b/builds/linux/opensuse/leap-15-6/linux-opensuse-leap.pkr.hcl
@@ -119,6 +119,7 @@ source "proxmox-iso" "linux-opensuse-leap" {
   memory          = "${var.vm_mem_size}"
   os              = "${var.vm_os_type}"
   scsi_controller = "${var.vm_disk_controller_type}"
+  vm_id           = var.vm_id_number
 
   disks {
     disk_size     = "${var.vm_disk_size}"

--- a/builds/linux/opensuse/leap-15-6/linux-opensuse-leap.pkrvars.hcl.example
+++ b/builds/linux/opensuse/leap-15-6/linux-opensuse-leap.pkrvars.hcl.example
@@ -26,6 +26,7 @@ vm_disk_size            = "32G"
 vm_disk_format          = "raw"
 vm_disk_controller_type = "virtio-scsi-pci"
 vm_network_card_model   = "virtio"
+vm_id                   = "10009"
 
 // Removable Media Settings
 iso_path     = "iso"

--- a/builds/linux/opensuse/leap-15-6/variables.pkr.hcl
+++ b/builds/linux/opensuse/leap-15-6/variables.pkr.hcl
@@ -88,6 +88,12 @@ variable "vm_bios" {
   }
 }
 
+variable "vm_id_number" {
+  type        = string
+  description = "standardized template number."
+  default = "10009"
+}  
+
 variable "vm_firmware_path" {
   type        = string
   description = "The firmware file to be used. Needed for EFI"

--- a/builds/linux/oracle/8/linux-oracle.pkr.hcl
+++ b/builds/linux/oracle/8/linux-oracle.pkr.hcl
@@ -122,6 +122,7 @@ source "proxmox-iso" "linux-oracle" {
   memory          = "${var.vm_mem_size}"
   os              = "${var.vm_os_type}"
   scsi_controller = "${var.vm_disk_controller_type}"
+  vm_id           = var.vm_id_number
 
   disks {
     disk_size     = "${var.vm_disk_size}"

--- a/builds/linux/oracle/8/linux-oracle.pkrvars.hcl.example
+++ b/builds/linux/oracle/8/linux-oracle.pkrvars.hcl.example
@@ -26,6 +26,7 @@ vm_disk_size            = "32G"
 vm_disk_format          = "raw"
 vm_disk_controller_type = "virtio-scsi-pci"
 vm_network_card_model   = "virtio"
+vm_id                   = "10008"
 
 // Removable Media Settings
 iso_path     = "iso"

--- a/builds/linux/oracle/8/variables.pkr.hcl
+++ b/builds/linux/oracle/8/variables.pkr.hcl
@@ -88,6 +88,12 @@ variable "vm_bios" {
   }
 }
 
+variable "vm_id_number" {
+  type        = string
+  description = "standardized template number."
+  default = "10008"
+} 
+
 variable "vm_firmware_path" {
   type        = string
   description = "The firmware file to be used. Needed for EFI"

--- a/builds/linux/oracle/9/linux-oracle.pkr.hcl
+++ b/builds/linux/oracle/9/linux-oracle.pkr.hcl
@@ -122,6 +122,7 @@ source "proxmox-iso" "linux-oracle" {
   memory          = "${var.vm_mem_size}"
   os              = "${var.vm_os_type}"
   scsi_controller = "${var.vm_disk_controller_type}"
+  vm_id           = var.vm_id_number
 
   disks {
     disk_size     = "${var.vm_disk_size}"

--- a/builds/linux/oracle/9/linux-oracle.pkrvars.hcl.example
+++ b/builds/linux/oracle/9/linux-oracle.pkrvars.hcl.example
@@ -26,6 +26,7 @@ vm_disk_size            = "32G"
 vm_disk_format          = "raw"
 vm_disk_controller_type = "virtio-scsi-pci"
 vm_network_card_model   = "virtio"
+vm_id                   = "10007"
 
 // Removable Media Settings
 iso_path     = "iso"

--- a/builds/linux/oracle/9/variables.pkr.hcl
+++ b/builds/linux/oracle/9/variables.pkr.hcl
@@ -88,6 +88,12 @@ variable "vm_bios" {
   }
 }
 
+variable "vm_id_number" {
+  type        = string
+  description = "standardized template number."
+  default = "10007"
+}
+
 variable "vm_firmware_path" {
   type        = string
   description = "The firmware file to be used. Needed for EFI"

--- a/builds/linux/rocky/10/linux-rocky.pkr.hcl
+++ b/builds/linux/rocky/10/linux-rocky.pkr.hcl
@@ -122,6 +122,7 @@ source "proxmox-iso" "linux-rocky" {
   memory          = "${var.vm_mem_size}"
   os              = "${var.vm_os_type}"
   scsi_controller = "${var.vm_disk_controller_type}"
+  vm_id           = var.vm_id_number
 
   disks {
     disk_size     = "${var.vm_disk_size}"

--- a/builds/linux/rocky/10/linux-rocky.pkrvars.hcl.example
+++ b/builds/linux/rocky/10/linux-rocky.pkrvars.hcl.example
@@ -26,6 +26,7 @@ vm_disk_size            = "32G"
 vm_disk_format          = "raw"
 vm_disk_controller_type = "virtio-scsi-pci"
 vm_network_card_model   = "virtio"
+vm_id                   = "10004"
 
 // Removable Media Settings
 iso_path     = "iso"

--- a/builds/linux/rocky/10/variables.pkr.hcl
+++ b/builds/linux/rocky/10/variables.pkr.hcl
@@ -311,3 +311,9 @@ variable "additional_packages" {
   description = "Additional packages to install."
   default     = []
 }
+
+variable "vm_id_number" {
+  type        = string
+  description = "standardized template number."
+  default = "10004"
+}

--- a/builds/linux/rocky/8/linux-rocky.pkr.hcl
+++ b/builds/linux/rocky/8/linux-rocky.pkr.hcl
@@ -122,6 +122,7 @@ source "proxmox-iso" "linux-rocky" {
   memory          = "${var.vm_mem_size}"
   os              = "${var.vm_os_type}"
   scsi_controller = "${var.vm_disk_controller_type}"
+  vm_id           = var.vm_id_number
 
   disks {
     disk_size     = "${var.vm_disk_size}"

--- a/builds/linux/rocky/8/linux-rocky.pkrvars.hcl.example
+++ b/builds/linux/rocky/8/linux-rocky.pkrvars.hcl.example
@@ -26,6 +26,7 @@ vm_disk_size            = "32G"
 vm_disk_format          = "raw"
 vm_disk_controller_type = "virtio-scsi-pci"
 vm_network_card_model   = "virtio"
+vm_id                   = "10006"
 
 // Removable Media Settings
 iso_path     = "iso"

--- a/builds/linux/rocky/8/variables.pkr.hcl
+++ b/builds/linux/rocky/8/variables.pkr.hcl
@@ -88,6 +88,12 @@ variable "vm_bios" {
   }
 }
 
+variable "vm_id_number" {
+  type        = string
+  description = "standardized template number."
+  default = "10006"
+}  
+
 variable "vm_firmware_path" {
   type        = string
   description = "The firmware file to be used. Needed for EFI"

--- a/builds/linux/rocky/9/linux-rocky.pkr.hcl
+++ b/builds/linux/rocky/9/linux-rocky.pkr.hcl
@@ -122,7 +122,8 @@ source "proxmox-iso" "linux-rocky" {
   memory          = "${var.vm_mem_size}"
   os              = "${var.vm_os_type}"
   scsi_controller = "${var.vm_disk_controller_type}"
-
+  vm_id           = var.vm_id_number
+  
   disks {
     disk_size     = "${var.vm_disk_size}"
     type          = "${var.vm_disk_type}"

--- a/builds/linux/rocky/9/linux-rocky.pkrvars.hcl.example
+++ b/builds/linux/rocky/9/linux-rocky.pkrvars.hcl.example
@@ -26,6 +26,7 @@ vm_disk_size            = "32G"
 vm_disk_format          = "raw"
 vm_disk_controller_type = "virtio-scsi-pci"
 vm_network_card_model   = "virtio"
+vm_id                   = "10005"
 
 // Removable Media Settings
 iso_path     = "iso"

--- a/builds/linux/rocky/9/variables.pkr.hcl
+++ b/builds/linux/rocky/9/variables.pkr.hcl
@@ -88,6 +88,12 @@ variable "vm_bios" {
   }
 }
 
+variable "vm_id_number" {
+  type        = string
+  description = "standardized template number."
+  default = "10005"
+}
+
 variable "vm_firmware_path" {
   type        = string
   description = "The firmware file to be used. Needed for EFI"

--- a/builds/linux/ubuntu/20-04-lts/linux-ubuntu.pkr.hcl
+++ b/builds/linux/ubuntu/20-04-lts/linux-ubuntu.pkr.hcl
@@ -129,6 +129,7 @@ source "proxmox-iso" "ubuntu" {
   memory          = "${var.vm_mem_size}"
   os              = "${var.vm_os_type}"
   scsi_controller = "${var.vm_disk_controller_type}"
+  vm_id           = var.vm_id_number
 
   disks {
     disk_size     = "${var.vm_disk_size}"

--- a/builds/linux/ubuntu/20-04-lts/linux-ubuntu.pkrvars.hcl.example
+++ b/builds/linux/ubuntu/20-04-lts/linux-ubuntu.pkrvars.hcl.example
@@ -26,6 +26,7 @@ vm_disk_size            = "32G"
 vm_disk_format          = "raw"
 vm_disk_controller_type = "virtio-scsi-pci"
 vm_network_card_model   = "virtio"
+vm_id                   = "10003"
 
 // Removable Media Settings
 iso_path     = "iso"

--- a/builds/linux/ubuntu/20-04-lts/variables.pkr.hcl
+++ b/builds/linux/ubuntu/20-04-lts/variables.pkr.hcl
@@ -88,6 +88,12 @@ variable "vm_bios" {
   }
 }
 
+variable "vm_id_number" {
+  type        = string
+  description = "standardized template number."
+  default = "10003"
+}
+
 variable "vm_firmware_path" {
   type        = string
   description = "The firmware file to be used. Needed for EFI"

--- a/builds/linux/ubuntu/22-04-lts/linux-ubuntu.pkr.hcl
+++ b/builds/linux/ubuntu/22-04-lts/linux-ubuntu.pkr.hcl
@@ -125,6 +125,7 @@ source "proxmox-iso" "ubuntu" {
   memory          = "${var.vm_mem_size}"
   os              = "${var.vm_os_type}"
   scsi_controller = "${var.vm_disk_controller_type}"
+  vm_id           = var.vm_id_number
 
   disks {
     disk_size     = "${var.vm_disk_size}"

--- a/builds/linux/ubuntu/22-04-lts/linux-ubuntu.pkrvars.hcl.example
+++ b/builds/linux/ubuntu/22-04-lts/linux-ubuntu.pkrvars.hcl.example
@@ -26,6 +26,7 @@ vm_disk_size            = "32G"
 vm_disk_format          = "raw"
 vm_disk_controller_type = "virtio-scsi-pci"
 vm_network_card_model   = "virtio"
+vm_id                   = "1000"
 
 // Removable Media Settings
 iso_path     = "iso"

--- a/builds/linux/ubuntu/22-04-lts/variables.pkr.hcl
+++ b/builds/linux/ubuntu/22-04-lts/variables.pkr.hcl
@@ -94,6 +94,12 @@ variable "vm_firmware_path" {
   default     = "/usr/share/ovmf/OVMF.fd"
 }
 
+variable "vm_id_number" {
+  type        = string
+  description = "standardized template number."
+  default = "10002"
+}
+
 variable "vm_efi_storage_pool" {
   type        = string
   description = "Set the UEFI disk storage location. (e.g. 'local-lvm')"

--- a/builds/linux/ubuntu/24-04-lts/linux-ubuntu.pkr.hcl
+++ b/builds/linux/ubuntu/24-04-lts/linux-ubuntu.pkr.hcl
@@ -125,7 +125,8 @@ source "proxmox-iso" "ubuntu" {
   memory          = "${var.vm_mem_size}"
   os              = "${var.vm_os_type}"
   scsi_controller = "${var.vm_disk_controller_type}"
-
+  vm_id           = var.vm_id_number
+  
   disks {
     disk_size     = "${var.vm_disk_size}"
     type          = "${var.vm_disk_type}"

--- a/builds/linux/ubuntu/24-04-lts/linux-ubuntu.pkrvars.hcl.example
+++ b/builds/linux/ubuntu/24-04-lts/linux-ubuntu.pkrvars.hcl.example
@@ -26,6 +26,7 @@ vm_disk_size            = "32G"
 vm_disk_format          = "raw"
 vm_disk_controller_type = "virtio-scsi-pci"
 vm_network_card_model   = "virtio"
+vm_id                   = "10001"
 
 // Removable Media Settings
 iso_path     = "iso"

--- a/builds/linux/ubuntu/24-04-lts/variables.pkr.hcl
+++ b/builds/linux/ubuntu/24-04-lts/variables.pkr.hcl
@@ -88,6 +88,12 @@ variable "vm_bios" {
   }
 }
 
+variable "vm_id_number" {
+  type        = string
+  description = "standardized template number."
+  default = "10001"
+}
+
 variable "vm_firmware_path" {
   type        = string
   description = "The firmware file to be used. Needed for EFI"

--- a/builds/windows/desktop/11/variables.pkr.hcl
+++ b/builds/windows/desktop/11/variables.pkr.hcl
@@ -414,3 +414,9 @@ variable "common_hcp_packer_registry_enabled" {
   description = "Enable the HCP Packer registry."
   default     = false
 }
+
+variable "vm_id_number" {
+  type        = string
+  description = "standardized template number."
+  default = "10000"
+}

--- a/builds/windows/desktop/11/windows.pkr.hcl
+++ b/builds/windows/desktop/11/windows.pkr.hcl
@@ -72,6 +72,7 @@ source "proxmox-iso" "windows-desktop-pro" {
   os              = var.vm_os_type
   qemu_agent      = true
   scsi_controller = var.vm_disk_controller_type
+  vm_id           = var.vm_id_number
 
   disks {
     disk_size     = var.vm_disk_size

--- a/builds/windows/desktop/11/windows.pkrvars.hcl.example
+++ b/builds/windows/desktop/11/windows.pkrvars.hcl.example
@@ -43,6 +43,7 @@ vm_disk_size            = "32G"
 vm_disk_format          = "raw"
 vm_disk_controller_type = "virtio-scsi-single"
 vm_network_card_model   = "virtio"
+vm_id_number            = "10000"
 
 // Removable Media Settings
 iso_path     = "iso"


### PR DESCRIPTION
<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/ajschroeder/proxmox-packer-examples/blob/main/.github/CONTRIBUTING.md) for making a pull request.

-->

# <!-- Intentionally left blank. -->

## Summary of Pull Request

Adding vm_id to templates to set static config

## Type of Pull Request



- [ ] This is a bugfix. `type/bug`
- [X ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)?

  For example:
  - Resolves #1
-->

Issue Number: #1 

## Test and Documentation Coverage


- [X ] Tests have been completed.
- [ ] Documentation has been added or updated.

## Breaking Changes?


- [ ] Yes, there are breaking changes.
- [ X] No, there are no breaking changes.

