### PR TITLE
Add NixOS 25.11 Packer template and QEMU smoke test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,8 +44,12 @@ plugin.hwm
 plugin.pwd
 plugin.pwi
 
+.gitmodules
+
 *.log
 
 # Local QEMU test SSH keys
 tests/ubuntu-qemu/test_ssh_key
+
+# SpecStory
 .specstory/

--- a/README.md
+++ b/README.md
@@ -225,6 +225,29 @@ Configuration templates are automatically created when you run `./docker-build.s
 
 Then customize the `.pkrvars.hcl` files for your infrastructure.
 
+### Local NixOS QEMU Smoke Test
+
+The NixOS template also has a local Packer+QEMU smoke test under `tests/nixos-qemu`.
+
+This path is useful for iterating on the installer boot sequence and generated `configuration.nix` without needing Proxmox credentials.
+
+Requirements:
+
+- `packer`
+- `qemu-system-x86_64`
+- `qemu-img`
+
+Example:
+
+```shell
+cp tests/nixos-qemu/test.pkrvars.hcl.example tests/nixos-qemu/test.pkrvars.hcl
+./tests/nixos-qemu/run.sh
+```
+
+The QEMU smoke test currently defaults to a BIOS install path to keep local testing simple. The main Proxmox NixOS build remains available under `builds/linux/nixos/25.11`.
+
+The `config` folder is the default folder. You can override the default by passing an alternate value as the first argument.
+
 ### Essential Configuration Files
 
 #### 1. Proxmox Connection (`config/proxmox.pkrvars.hcl`)

--- a/build.sh
+++ b/build.sh
@@ -832,6 +832,43 @@ menu_option_21() {
   echo "Done."
 }
 
+menu_option_22() {
+  INPUT_PATH="$SCRIPT_PATH"/builds/linux/nixos/25.11/
+  BUILD_PATH=${INPUT_PATH#"${SCRIPT_PATH}/builds/"}
+  BUILD_VARS="$(echo "${BUILD_PATH%/}" | tr -s '/' | tr '/' '-').pkrvars.hcl"
+
+  echo -e "\nCONFIRM: Build a NixOS 25.11 Template for Proxmox?"
+  echo -e "\nContinue? (y/n)"
+  read -r REPLY
+  if [[ ! $REPLY =~ ^[Yy]$ ]]
+  then
+    exit 1
+  fi
+
+  ### Build a NixOS 25.11 Template for Proxmox. ###
+  echo "Building a NixOS 25.11 Template for Proxmox..."
+
+  ### Initialize HashiCorp Packer and required plugins. ###
+  echo "Initializing HashiCorp Packer and required plugins..."
+  packer init "$INPUT_PATH"
+
+  ### Start the Build. ###
+  echo "Starting the build...."
+  echo "packer build -force -on-error=ask $debug_option"
+  packer build -force -on-error=ask $debug_option \
+      -var-file="$CONFIG_PATH/ansible.pkrvars.hcl" \
+      -var-file="$CONFIG_PATH/build.pkrvars.hcl" \
+      -var-file="$CONFIG_PATH/common.pkrvars.hcl" \
+      -var-file="$CONFIG_PATH/linux-storage.pkrvars.hcl" \
+      -var-file="$CONFIG_PATH/network.pkrvars.hcl" \
+      -var-file="$CONFIG_PATH/proxmox.pkrvars.hcl" \
+      -var-file="$CONFIG_PATH/$BUILD_VARS" \
+      "$INPUT_PATH"
+
+  ### All done. ###
+  echo "Done."
+}
+
 press_enter() {
   cd "$SCRIPT_PATH"
   echo -n "Press Enter to continue."
@@ -885,6 +922,7 @@ until [ "$selection" = "0" ]; do
   echo "       19 -  Windows 11 - Enterprise Only"
   echo "       20 -  Windows 11 - Professional Only"
   echo "       21 -  Ubuntu Server 26.04 LTS"
+  echo "       22 -  NixOS 25.11"
   echo ""
   echo "      Other:"
   echo ""
@@ -915,6 +953,7 @@ until [ "$selection" = "0" ]; do
     19) clear ; menu_option_19 ; press_enter ;;
     20) clear ; menu_option_20 ; press_enter ;;
     21) clear ; menu_option_21 ; press_enter ;;
+    22) clear ; menu_option_22 ; press_enter ;;
     [Ii] ) clear ; info ; press_enter ;;
     [Qq] ) clear ; exit ;;
     * ) clear ; incorrect_selection ; press_enter ;;

--- a/builds/linux/nixos/25.11/data/configuration.pkrtpl.nix
+++ b/builds/linux/nixos/25.11/data/configuration.pkrtpl.nix
@@ -1,0 +1,60 @@
+{ config, pkgs, lib, ... }:
+
+{
+  imports = [
+    ./hardware-configuration.nix
+  ];
+
+  boot.kernelParams = [ "net.ifnames=0" "biosdevname=0" ];
+%{ if vm_bios == "ovmf" ~}
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
+%{ else ~}
+  boot.loader.grub.enable = true;
+  boot.loader.grub.device = "/dev/${vm_disk_device}";
+%{ endif ~}
+
+  networking.hostName = "${vm_os_name}";
+  networking.usePredictableInterfaceNames = false;
+%{ if vm_ip_address != null ~}
+  networking.useDHCP = false;
+  networking.defaultGateway = "${vm_ip_gateway}";
+  networking.nameservers = [
+%{ for dns in vm_dns_list ~}
+    "${dns}"
+%{ endfor ~}
+  ];
+  networking.interfaces."${vm_network_device}".ipv4.addresses = [
+    {
+      address = "${vm_ip_address}";
+      prefixLength = ${vm_ip_netmask};
+    }
+  ];
+%{ else ~}
+  networking.useDHCP = false;
+  networking.interfaces."${vm_network_device}".useDHCP = true;
+%{ endif ~}
+
+  services.openssh.enable = true;
+  services.openssh.settings.PasswordAuthentication = true;
+  services.openssh.settings.PermitRootLogin = "no";
+  services.qemuGuest.enable = true;
+
+  security.sudo.wheelNeedsPassword = false;
+  users.mutableUsers = false;
+  users.users."${build_username}" = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    hashedPassword = "${build_password_encrypted}";
+  };
+
+  environment.systemPackages = with pkgs; [
+    curl
+    git
+    python3
+    qemu
+  ];
+
+  nix.settings.experimental-features = [ "nix-command" "flakes" ];
+  system.stateVersion = "${vm_os_version}";
+}

--- a/builds/linux/nixos/25.11/linux-nixos.pkr.hcl
+++ b/builds/linux/nixos/25.11/linux-nixos.pkr.hcl
@@ -1,0 +1,217 @@
+/*
+    DESCRIPTION:
+    NixOS 25.11 template using the Packer Builder for Proxmox (proxmox-iso).
+*/
+
+//  BLOCK: packer
+//  The Packer configuration.
+
+packer {
+  required_version = ">= 1.12.0"
+  required_plugins {
+    ansible = {
+      source  = "github.com/hashicorp/ansible"
+      version = "~> 1"
+    }
+    git = {
+      version = ">= 0.6.2"
+      source  = "github.com/ethanmdavidson/git"
+    }
+    proxmox = {
+      version = "= 1.2.1"
+      source  = "github.com/hashicorp/proxmox"
+    }
+  }
+}
+
+//  BLOCK: data
+//  Defines the data sources.
+
+data "git-repository" "cwd" {}
+
+//  BLOCK: locals
+//  Defines the local variables.
+
+locals {
+  build_by          = "Built by: HashiCorp Packer ${packer.version}"
+  build_date        = formatdate("DD-MM-YYYY hh:mm ZZZ", "${timestamp()}")
+  build_version     = data.git-repository.cwd.head
+  build_description = "Version: ${local.build_version}\nBuilt on: ${local.build_date}\n${local.build_by}\nCloud-Init: ${var.vm_cloudinit}"
+  manifest_date     = formatdate("YYYY-MM-DD hh:mm:ss", timestamp())
+  manifest_path     = "${path.cwd}/manifests/"
+  manifest_output   = "${local.manifest_path}${local.manifest_date}.json"
+  vm_name           = "${var.vm_os_family}-${var.vm_os_name}-${var.vm_os_version}"
+  install_disk      = "/dev/${var.vm_disk_device}"
+  efi_partition     = "${local.install_disk}1"
+  root_partition    = var.vm_bios == "ovmf" ? "${local.install_disk}2" : "${local.install_disk}1"
+  partition_command = var.vm_bios == "ovmf" ? "parted -s ${local.install_disk} mklabel gpt mkpart ESP fat32 1MiB 512MiB set 1 esp on mkpart primary ext4 512MiB 100%" : "parted -s ${local.install_disk} mklabel msdos mkpart primary ext4 1MiB 100% set 1 boot on"
+  config_copy_command = var.common_data_source == "http" ? "curl -fsSL http://{{ .HTTPIP }}:{{ .HTTPPort }}/configuration.nix -o /mnt/etc/nixos/configuration.nix" : "mkdir -p /tmp/nixos-config && mount /dev/sr1 /tmp/nixos-config && cp /tmp/nixos-config/configuration.nix /mnt/etc/nixos/configuration.nix"
+  data_source_content = {
+    "/configuration.nix" = templatefile("${abspath(path.root)}/data/configuration.pkrtpl.nix", {
+      build_username           = var.build_username
+      build_password_encrypted = var.build_password_encrypted
+      vm_bios                  = var.vm_bios
+      vm_disk_device           = var.vm_disk_device
+      vm_network_device        = var.vm_network_device
+      vm_ip_address            = var.vm_ip_address
+      vm_ip_netmask            = var.vm_ip_netmask
+      vm_ip_gateway            = var.vm_ip_gateway
+      vm_dns_list              = var.vm_dns_list
+      vm_os_name               = var.vm_os_name
+      vm_os_version            = var.vm_os_version
+    })
+  }
+  boot_command = concat([
+    "<enter><wait90s>",
+    "${local.partition_command}<enter><wait5s>",
+  ], var.vm_bios == "ovmf" ? [
+    "mkfs.fat -F 32 ${local.efi_partition}<enter><wait5s>",
+  ] : [], [
+    "mkfs.ext4 -F ${local.root_partition}<enter><wait5s>",
+    "mount ${local.root_partition} /mnt<enter><wait2s>",
+  ], var.vm_bios == "ovmf" ? [
+    "mkdir -p /mnt/boot<enter><wait>",
+    "mount ${local.efi_partition} /mnt/boot<enter><wait2s>",
+  ] : [], [
+    "nixos-generate-config --root /mnt<enter><wait10s>",
+    "${local.config_copy_command}<enter><wait5s>",
+    "nixos-install --no-root-password<enter><wait300s>",
+    "shutdown -h now<enter>",
+  ])
+  vm_bios = var.vm_bios == "ovmf" ? var.vm_firmware_path : null
+}
+
+//  BLOCK: source
+//  Defines the builder configuration blocks.
+
+source "proxmox-iso" "nixos" {
+
+  // Proxmox Connection Settings and Credentials
+  proxmox_url              = "https://${var.proxmox_hostname}:8006/api2/json"
+  username                 = "${var.proxmox_api_token_id}"
+  token                    = "${var.proxmox_api_token_secret}"
+  insecure_skip_tls_verify = "${var.proxmox_insecure_connection}"
+
+  // Proxmox Settings
+  node = "${var.proxmox_node}"
+
+  // Virtual Machine Settings
+  vm_name         = "${local.vm_name}"
+  bios            = "${var.vm_bios}"
+  sockets         = "${var.vm_cpu_sockets}"
+  cores           = "${var.vm_cpu_count}"
+  cpu_type        = "${var.vm_cpu_type}"
+  memory          = "${var.vm_mem_size}"
+  os              = "${var.vm_os_type}"
+  scsi_controller = "${var.vm_disk_controller_type}"
+  vm_id           = var.vm_id_number
+
+  disks {
+    disk_size    = "${var.vm_disk_size}"
+    type         = "${var.vm_disk_type}"
+    storage_pool = "${var.vm_storage_pool}"
+    format       = "${var.vm_disk_format}"
+  }
+
+  dynamic "efi_config" {
+    for_each = var.vm_bios == "ovmf" ? [1] : []
+    content {
+      efi_storage_pool  = var.vm_bios == "ovmf" ? var.vm_efi_storage_pool : null
+      efi_type          = var.vm_bios == "ovmf" ? var.vm_efi_type : null
+      pre_enrolled_keys = var.vm_bios == "ovmf" ? var.vm_efi_pre_enrolled_keys : null
+    }
+  }
+
+  ssh_username = "${var.build_username}"
+  ssh_password = "${var.build_password}"
+  ssh_timeout  = "${var.timeout}"
+  ssh_port     = "22"
+  qemu_agent   = true
+
+  network_adapters {
+    bridge   = "${var.vm_bridge_interface}"
+    model    = "${var.vm_network_card_model}"
+    vlan_tag = "${var.vm_vlan_tag}"
+  }
+
+  // Removable Media Settings
+  http_content = var.common_data_source == "http" ? local.data_source_content : null
+
+  // Boot and Provisioning Settings
+  http_interface    = var.common_data_source == "http" ? var.common_http_interface : null
+  http_bind_address = var.common_data_source == "http" ? var.common_http_bind_address : null
+  http_port_min     = var.common_data_source == "http" ? var.common_http_port_min : null
+  http_port_max     = var.common_data_source == "http" ? var.common_http_port_max : null
+  boot              = var.vm_boot
+  boot_wait         = var.vm_boot_wait
+  boot_command      = local.boot_command
+
+  boot_iso {
+    iso_file     = "${var.common_iso_storage}:${var.iso_path}/${var.iso_file}"
+    unmount      = true
+    iso_checksum = "${var.iso_checksum}"
+  }
+
+  dynamic "additional_iso_files" {
+    for_each = var.common_data_source == "disk" ? [1] : []
+    content {
+      cd_files         = var.common_data_source == "disk" ? local.data_source_content : null
+      cd_label         = var.common_data_source == "disk" ? "cidata" : null
+      iso_storage_pool = var.common_data_source == "disk" ? "local" : null
+    }
+  }
+
+  template_name        = "${local.vm_name}"
+  template_description = "${local.build_description}"
+
+  # VM Cloud Init Settings
+  cloud_init              = var.vm_cloudinit
+  cloud_init_storage_pool = var.vm_cloudinit == true ? var.vm_storage_pool : null
+  cloud_init_disk_type    = var.vm_cloudinit_disk_type
+}
+
+# Build Definition to create the VM Template
+build {
+  sources = ["source.proxmox-iso.nixos"]
+
+  provisioner "ansible" {
+    user                   = var.build_username
+    galaxy_file            = "${path.cwd}/ansible/linux-requirements.yml"
+    galaxy_force_with_deps = true
+    playbook_file          = "${path.cwd}/ansible/linux-playbook.yml"
+    roles_path             = "${path.cwd}/ansible/roles"
+    ansible_env_vars = [
+      "ANSIBLE_CONFIG=${path.cwd}/ansible/ansible.cfg",
+      "ANSIBLE_PYTHON_INTERPRETER=/run/current-system/sw/bin/python3"
+    ]
+    extra_arguments = [
+      "--extra-vars", "display_skipped_hosts=false",
+      "--extra-vars", "build_username=${var.build_username}",
+      "--extra-vars", "build_key='${var.build_key}'",
+      "--extra-vars", "ansible_username=${var.ansible_username}",
+      "--extra-vars", "ansible_key='${var.ansible_key}'",
+      "--extra-vars", "enable_cloudinit='${var.vm_cloudinit}'",
+    ]
+  }
+
+  post-processor "manifest" {
+    output     = local.manifest_output
+    strip_path = true
+    strip_time = true
+    custom_data = {
+      ansible_username      = "${var.ansible_username}"
+      build_username        = "${var.build_username}"
+      build_date            = "${local.build_date}"
+      build_version         = "${local.build_version}"
+      common_data_source    = "${var.common_data_source}"
+      vm_cpu_sockets        = "${var.vm_cpu_sockets}"
+      vm_cpu_count          = "${var.vm_cpu_count}"
+      vm_disk_size          = "${var.vm_disk_size}"
+      vm_bios               = "${var.vm_bios}"
+      vm_os_type            = "${var.vm_os_type}"
+      vm_mem_size           = "${var.vm_mem_size}"
+      vm_network_card_model = "${var.vm_network_card_model}"
+      vm_cloudinit          = "${var.vm_cloudinit}"
+    }
+  }
+}

--- a/builds/linux/nixos/25.11/linux-nixos.pkrvars.hcl.example
+++ b/builds/linux/nixos/25.11/linux-nixos.pkrvars.hcl.example
@@ -1,0 +1,41 @@
+/*
+    DESCRIPTION:
+    NixOS 25.11 variables used by the Packer Plugin for Proxmox (proxmox-iso).
+*/
+
+// Guest Operating System Metadata
+vm_os_language = "en_US"
+vm_os_keyboard = "us"
+vm_os_timezone = "UTC"
+vm_os_family   = "linux"
+vm_os_name     = "nixos"
+vm_os_version  = "25.11"
+
+// Virtual Machine Guest Operating System Setting
+vm_os_type   = "l26"
+vm_cloudinit = false
+
+// Virtual Machine Hardware Settings
+vm_bios                 = "ovmf"
+vm_cpu_count            = 2
+vm_cpu_sockets          = 1
+vm_cpu_type             = "x86-64-v2-AES"
+vm_mem_size             = 4096
+vm_disk_type            = "virtio"
+vm_disk_size            = "32G"
+vm_disk_format          = "raw"
+vm_disk_controller_type = "virtio-scsi-pci"
+vm_network_card_model   = "virtio"
+vm_id_number            = "10016"
+
+// Removable Media Settings
+iso_path     = "iso"
+iso_file     = "nixos-minimal-25.11.9586.10e7ad5bbcb4-x86_64-linux.iso"
+iso_checksum = "sha256:bb1fd0200cbf9070f67c7e6a476d962762626abbc0650b1b31c084fc4fc7656c"
+
+// Boot Settings
+vm_boot      = "order=virtio0;ide2;net0"
+vm_boot_wait = "5s"
+
+// EFI Settings
+vm_firmware_path = "./OVMF.fd"

--- a/builds/linux/nixos/25.11/variables-network.pkr.hcl
+++ b/builds/linux/nixos/25.11/variables-network.pkr.hcl
@@ -1,0 +1,36 @@
+/*
+    DESCRIPTION:
+    NixOS 25.11 network variables used by the Packer Plugin for Proxmox (proxmox-iso).
+*/
+
+// VM Network Settings
+
+variable "vm_network_device" {
+  type        = string
+  description = "The network device of the VM."
+  default     = "eth0"
+}
+
+variable "vm_ip_address" {
+  type        = string
+  description = "The IP address of the VM (e.g. 172.16.100.192)."
+  default     = null
+}
+
+variable "vm_ip_netmask" {
+  type        = number
+  description = "The netmask of the VM (e.g. 24)."
+  default     = null
+}
+
+variable "vm_ip_gateway" {
+  type        = string
+  description = "The gateway of the VM (e.g. 172.16.100.1)."
+  default     = null
+}
+
+variable "vm_dns_list" {
+  type        = list(string)
+  description = "The nameservers of the VM."
+  default     = []
+}

--- a/builds/linux/nixos/25.11/variables-storage.pkr.hcl
+++ b/builds/linux/nixos/25.11/variables-storage.pkr.hcl
@@ -1,0 +1,53 @@
+/*
+    DESCRIPTION:
+    NixOS 25.11 storage variables used by the Packer Plugin for Proxmox (proxmox-iso).
+*/
+
+// VM Storage Settings
+
+variable "vm_disk_device" {
+  type        = string
+  description = "The device for the virtual disk. (e.g. 'sda')"
+}
+
+variable "vm_disk_use_swap" {
+  type        = bool
+  description = "Whether to use a swap partition."
+}
+
+variable "vm_disk_partitions" {
+  type = list(object({
+    name = string
+    size = number
+    format = object({
+      label  = string
+      fstype = string
+    })
+    mount = object({
+      path    = string
+      options = string
+    })
+    volume_group = string
+  }))
+  description = "The disk partitions for the virtual disk."
+}
+
+variable "vm_disk_lvm" {
+  type = list(object({
+    name = string
+    partitions = list(object({
+      name = string
+      size = number
+      format = object({
+        label  = string
+        fstype = string
+      })
+      mount = object({
+        path    = string
+        options = string
+      })
+    }))
+  }))
+  description = "The LVM configuration for the virtual disk."
+  default     = []
+}

--- a/builds/linux/nixos/25.11/variables.pkr.hcl
+++ b/builds/linux/nixos/25.11/variables.pkr.hcl
@@ -1,0 +1,325 @@
+/*
+    DESCRIPTION:
+    NixOS 25.11 variables using the Packer Builder for Proxmox (proxmox-iso).
+*/
+
+//  BLOCK: variable
+//  Defines the input variables.
+
+// Proxmox Credentials
+
+variable "proxmox_hostname" {
+  type        = string
+  description = "The FQDN or IP address of a Proxmox node. Only one node should be specified in a cluster."
+}
+
+variable "proxmox_api_token_id" {
+  type        = string
+  description = "The token to login to the Proxmox node/cluster. The format is USER@REALM!TOKENID. (e.g. packer@pam!packer_pve_token)"
+}
+
+variable "proxmox_api_token_secret" {
+  type        = string
+  description = "The secret for the API token used to login to the Proxmox API."
+#  sensitive   = true
+}
+
+variable "proxmox_insecure_connection" {
+  description = "true/false to skip Proxmox TLS certificate checks."
+  type        = bool
+  default     = true
+}
+
+// Proxmox Settings
+
+variable "proxmox_node" {
+  type        = string
+  description = "The name of the Proxmox node that Packer will build templates on."
+}
+
+// Virtual Machine Settings
+
+variable "vm_os_language" {
+  type        = string
+  description = "The guest operating system language."
+  default     = "en_US"
+}
+
+variable "vm_os_keyboard" {
+  type        = string
+  description = "The guest operating system keyboard layout."
+  default     = "us"
+}
+
+variable "vm_os_timezone" {
+  type        = string
+  description = "The guest operating system timezone."
+  default     = "UTC"
+}
+
+variable "vm_os_family" {
+  type        = string
+  description = "The guest operating system family. Used for naming. (e.g. 'linux')"
+}
+
+variable "vm_os_name" {
+  type        = string
+  description = "The guest operating system name. Used for naming. (e.g. 'ubuntu')"
+}
+
+variable "vm_os_version" {
+  type        = string
+  description = "The guest operating system version. Used for naming. (e.g. '25.11')"
+}
+
+variable "vm_os_type" {
+  type        = string
+  description = "The guest operating system type. (e.g. 'l26')"
+}
+
+variable "vm_bios" {
+  type        = string
+  description = "The firmware type. Allowed values 'ovmf' or 'seabios'"
+  default     = "ovmf"
+
+  validation {
+    condition     = contains(["ovmf", "seabios"], var.vm_bios)
+    error_message = "The vm_bios value must be 'ovmf' or 'seabios'."
+  }
+}
+
+variable "vm_id_number" {
+  type        = string
+  description = "standardized template number."
+  default     = "10016"
+}
+
+variable "vm_firmware_path" {
+  type        = string
+  description = "The firmware file to be used. Needed for EFI"
+  default     = "/usr/share/ovmf/OVMF.fd"
+}
+
+variable "vm_efi_storage_pool" {
+  type        = string
+  description = "Set the UEFI disk storage location. (e.g. 'local-lvm')"
+  default     = "local-lvm"
+}
+
+variable "vm_efi_type" {
+  type        = string
+  description = "Specifies the version of the OVMF firmware to be used. (e.g. '4m')"
+  default     = "4m"
+}
+
+variable "vm_efi_pre_enrolled_keys" {
+  type        = bool
+  description = "Whether Microsoft Standard Secure Boot keys should be pre-loaded on the EFI disk. (e.g. false)"
+  default     = false
+}
+
+variable "vm_cpu_count" {
+  type        = number
+  description = "The number of virtual CPUs. (e.g. '2')"
+}
+
+variable "vm_cpu_sockets" {
+  type        = number
+  description = "The number of virtual CPU sockets. (e.g. '1')"
+}
+
+variable "vm_cpu_type" {
+  type        = string
+  description = "The CPU type to emulate. See the Proxmox API documentation for the complete list of accepted values. For best performance, set this to host. Defaults to kvm64."
+}
+
+variable "vm_mem_size" {
+  type        = number
+  description = "The size for the virtual memory in MB. (e.g. '2048')"
+}
+
+variable "vm_disk_controller_type" {
+  type        = string
+  description = "The SCSI controller model to emulate. (e.g. 'virtio-scsi-pci')"
+}
+
+variable "vm_disk_type" {
+  type        = string
+  description = "The type of disk to emulate. (e.g. 'virtio')"
+}
+
+variable "vm_storage_pool" {
+  type        = string
+  description = "The name of the Proxmox storage pool to store the VM template. (e.g. 'local-lvm')"
+}
+
+variable "vm_disk_size" {
+  type        = string
+  description = "The size for the virtual disk in GB. (e.g. '32G')"
+}
+
+variable "vm_disk_format" {
+  type        = string
+  description = "The format of the file backing the disk. (e.g. 'qcow2')"
+}
+
+variable "vm_network_card_model" {
+  type        = string
+  description = "The model of the virtual network adapter to emulate. (e.g. 'virtio')"
+}
+
+variable "vm_bridge_interface" {
+  type        = string
+  description = "The name of the Proxmox bridge to attach the adapter to."
+}
+
+variable "vm_vlan_tag" {
+  type        = string
+  description = "If the adapter should tag packets, give the VLAN ID. (e.g. '102')"
+}
+
+// Cloud-Init Settings
+
+variable "vm_cloudinit" {
+  type        = bool
+  description = "Enable or disable cloud-init drive in Proxmox. (e.g. false)"
+  default     = false
+}
+
+variable "vm_cloudinit_disk_type" {
+  type        = string
+  description = "the disk controller used for the Cloud-Init CDROM drive. Example values ide, scsi, virtio."
+  default     = "ide"
+}
+
+// Removable Media Settings
+
+variable "common_iso_storage" {
+  type        = string
+  description = "The name of the source Proxmox storage location for ISO images. (e.g. 'local-lvm')"
+}
+
+variable "iso_path" {
+  type        = string
+  description = "The path on the source Proxmox storage location for ISO images. (e.g. 'iso')"
+}
+
+variable "iso_file" {
+  type        = string
+  description = "The file name of the ISO image used by the vendor."
+}
+
+variable "iso_checksum" {
+  type        = string
+  description = "The checksum value of the ISO image provided by the vendor."
+}
+
+// Boot Settings
+
+variable "common_data_source" {
+  type        = string
+  description = "The provisioning data source. (e.g. 'http' or 'disk')"
+}
+
+variable "common_http_bind_address" {
+  type        = string
+  description = "Define an IP address on the host to use for the HTTP server."
+  default     = null
+}
+
+variable "common_http_interface" {
+  type        = string
+  description = "Name of the network interface that Packer gets HTTPIP from. Defaults to the first non loopback interface."
+  default     = null
+}
+
+variable "common_http_port_min" {
+  type        = number
+  description = "The start of the HTTP port range."
+}
+
+variable "common_http_port_max" {
+  type        = number
+  description = "The end of the HTTP port range."
+}
+
+variable "vm_boot" {
+  type        = string
+  description = "The boot order for virtual machine devices. (e.g. 'order=virtio0;ide2;net0')"
+}
+
+variable "vm_boot_wait" {
+  type        = string
+  description = "The time to wait after booting the initial VM before typing the boot_command (e.g '10s')"
+}
+
+variable "common_ip_wait_timeout" {
+  type        = string
+  description = "Time to wait for guest operating system IP address response."
+}
+
+variable "common_shutdown_timeout" {
+  type        = string
+  description = "Time to wait for guest operating system shutdown."
+}
+
+// Communicator Settings and Credentials
+
+variable "build_username" {
+  type        = string
+  description = "The username to login to the guest operating system. (e.g. 'ubuntu')"
+#  sensitive   = true
+}
+
+variable "build_password" {
+  type        = string
+  description = "The password to login to the guest operating system."
+#  sensitive   = true
+}
+
+variable "build_password_encrypted" {
+  type        = string
+  description = "The encrypted password to login to the guest operating system."
+#  sensitive   = true
+}
+
+variable "build_key" {
+  type        = string
+  description = "The SSH public key to login to the guest operating system."
+#  sensitive   = true
+}
+
+variable "timeout" {
+  description = "not sure why I need so high a timeout but here we are"
+  default     = "90m"
+}
+
+// Ansible Credentials
+
+variable "ansible_username" {
+  type        = string
+  description = "The username for Ansible to login to the guest operating system. (e.g. 'ansible')"
+#  sensitive   = true
+}
+
+variable "ansible_key" {
+  type        = string
+  description = "The public key for Ansible to login to the guest operating system."
+#  sensitive   = true
+}
+
+// HCP Packer Settings
+
+variable "common_hcp_packer_registry_enabled" {
+  type        = bool
+  description = "Enable the HCP Packer registry."
+  default     = false
+}
+
+// Additional Settings
+
+variable "additional_packages" {
+  type        = list(string)
+  description = "Additional packages to install."
+  default     = []
+}

--- a/tests/nixos-qemu/.gitignore
+++ b/tests/nixos-qemu/.gitignore
@@ -1,2 +1,3 @@
 output/
 test.pkrvars.hcl
+serial.log

--- a/tests/nixos-qemu/.gitignore
+++ b/tests/nixos-qemu/.gitignore
@@ -1,0 +1,2 @@
+output/
+test.pkrvars.hcl

--- a/tests/nixos-qemu/install.pkrtpl.sh
+++ b/tests/nixos-qemu/install.pkrtpl.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+set -eu
+
+parted -s ${install_disk} mklabel msdos mkpart primary ext4 1MiB 100% set 1 boot on
+mkfs.ext4 -F ${install_disk}1
+mount ${install_disk}1 /mnt
+nixos-generate-config --root /mnt
+cp /tmp/nixos-config/configuration.nix /mnt/etc/nixos/configuration.nix
+nixos-install --no-root-password
+shutdown -h now

--- a/tests/nixos-qemu/run.sh
+++ b/tests/nixos-qemu/run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_PATH=$(realpath "$(dirname "$0")")
+VARS_FILE=${1:-"$SCRIPT_PATH/test.pkrvars.hcl"}
+
+if [ ! -f "$VARS_FILE" ]; then
+  echo "Missing vars file: $VARS_FILE"
+  echo "Copy $SCRIPT_PATH/test.pkrvars.hcl.example to test.pkrvars.hcl and adjust as needed."
+  exit 1
+fi
+
+packer init "$SCRIPT_PATH"
+packer build -var-file="$VARS_FILE" "$SCRIPT_PATH"

--- a/tests/nixos-qemu/test.pkr.hcl
+++ b/tests/nixos-qemu/test.pkr.hcl
@@ -56,7 +56,7 @@ source "qemu" "nixos" {
   net_device       = var.vm_network_card_model
   output_directory = var.output_directory
   qemuargs = [
-    ["-serial", "file:${var.output_directory}/serial.log"]
+    ["-serial", "file:${abspath(path.root)}/serial.log"]
   ]
   shutdown_timeout = var.shutdown_timeout
   vm_name          = "${var.vm_os_name}-${var.vm_os_version}-qemu"

--- a/tests/nixos-qemu/test.pkr.hcl
+++ b/tests/nixos-qemu/test.pkr.hcl
@@ -1,0 +1,67 @@
+packer {
+  required_version = ">= 1.12.0"
+  required_plugins {
+    qemu = {
+      source  = "github.com/hashicorp/qemu"
+      version = "~> 1"
+    }
+  }
+}
+
+locals {
+  install_disk = "/dev/${var.vm_disk_device}"
+  data_source_content = {
+    "/configuration.nix" = templatefile("${abspath(path.root)}/../../builds/linux/nixos/25.11/data/configuration.pkrtpl.nix", {
+      build_username           = var.build_username
+      build_password_encrypted = var.build_password_encrypted
+      vm_bios                  = var.vm_bios
+      vm_disk_device           = var.vm_disk_device
+      vm_network_device        = var.vm_network_device
+      vm_ip_address            = var.vm_ip_address
+      vm_ip_netmask            = var.vm_ip_netmask
+      vm_ip_gateway            = var.vm_ip_gateway
+      vm_dns_list              = var.vm_dns_list
+      vm_os_name               = var.vm_os_name
+      vm_os_version            = var.vm_os_version
+    })
+    "/install.sh" = templatefile("${abspath(path.root)}/install.pkrtpl.sh", {
+      install_disk = local.install_disk
+    })
+  }
+  boot_command = [
+    "<enter><wait180s>",
+    "mkdir -p /tmp/nixos-config<enter><wait>",
+    "sudo mount -L CIDATA /tmp/nixos-config || sudo mount /dev/sr1 /tmp/nixos-config || sudo mount /dev/sr0 /tmp/nixos-config<enter><wait2s>",
+    "sudo sh /tmp/nixos-config/install.sh<enter><wait60s>",
+  ]
+}
+
+source "qemu" "nixos" {
+  boot_command     = local.boot_command
+  boot_wait        = var.vm_boot_wait
+  boot_key_interval = "100ms"
+  communicator     = "none"
+  cpus             = var.vm_cpu_count
+  disk_cache       = "writeback"
+  disk_compression = true
+  disk_interface   = "virtio"
+  disk_size        = var.disk_size
+  format           = "qcow2"
+  headless         = var.headless
+  cd_content       = local.data_source_content
+  cd_label         = "CIDATA"
+  iso_checksum     = var.iso_checksum
+  iso_url          = var.iso_url
+  memory           = var.vm_mem_size
+  net_device       = var.vm_network_card_model
+  output_directory = var.output_directory
+  qemuargs = [
+    ["-serial", "file:${var.output_directory}/serial.log"]
+  ]
+  shutdown_timeout = var.shutdown_timeout
+  vm_name          = "${var.vm_os_name}-${var.vm_os_version}-qemu"
+}
+
+build {
+  sources = ["source.qemu.nixos"]
+}

--- a/tests/nixos-qemu/test.pkrvars.hcl.example
+++ b/tests/nixos-qemu/test.pkrvars.hcl.example
@@ -1,0 +1,11 @@
+iso_url      = "https://channels.nixos.org/nixos-25.11/latest-nixos-minimal-x86_64-linux.iso"
+iso_checksum = "sha256:bb1fd0200cbf9070f67c7e6a476d962762626abbc0650b1b31c084fc4fc7656c"
+
+# Set headless = true when running without a desktop session.
+headless = false
+
+# Uncomment to test a static network rendering.
+# vm_ip_address = "192.168.122.50"
+# vm_ip_netmask = 24
+# vm_ip_gateway = "192.168.122.1"
+# vm_dns_list   = ["1.1.1.1", "8.8.8.8"]

--- a/tests/nixos-qemu/variables.pkr.hcl
+++ b/tests/nixos-qemu/variables.pkr.hcl
@@ -1,0 +1,123 @@
+variable "build_username" {
+  type        = string
+  description = "The username to login to the guest operating system."
+  default     = "deploy"
+}
+
+variable "build_password_encrypted" {
+  type        = string
+  description = "The encrypted password to login to the guest operating system."
+  default     = "$6$MsfTs/5vjdnlgqEt$pkl1uGs645Y1NLpzQu7R/coOohkyzksn2YkY2EgjOuXkA6Tnrr3Yag8LYeotfYaiiyIzn3MyYCWdeqM.2VKAz1"
+}
+
+variable "disk_size" {
+  type        = string
+  description = "The output disk size for the QEMU image."
+  default     = "32G"
+}
+
+variable "headless" {
+  type        = bool
+  description = "Run the local QEMU test headless."
+  default     = false
+}
+
+variable "iso_checksum" {
+  type        = string
+  description = "The checksum value of the ISO image."
+}
+
+variable "iso_url" {
+  type        = string
+  description = "The NixOS ISO URL or local file path."
+}
+
+variable "output_directory" {
+  type        = string
+  description = "The directory where the built QEMU artifact will be written."
+  default     = "output/nixos-25.11"
+}
+
+variable "shutdown_timeout" {
+  type        = string
+  description = "How long to wait for the installer to shut down."
+  default     = "45m"
+}
+
+variable "vm_bios" {
+  type        = string
+  description = "The firmware type. The local QEMU smoke test uses BIOS by default."
+  default     = "seabios"
+}
+
+variable "vm_boot_wait" {
+  type        = string
+  description = "The time to wait after booting the ISO before typing boot commands."
+  default     = "5s"
+}
+
+variable "vm_cpu_count" {
+  type        = number
+  description = "The number of virtual CPUs."
+  default     = 2
+}
+
+variable "vm_disk_device" {
+  type        = string
+  description = "The guest disk device name used during installation."
+  default     = "vda"
+}
+
+variable "vm_ip_address" {
+  type        = string
+  description = "The IP address of the VM."
+  default     = null
+}
+
+variable "vm_ip_gateway" {
+  type        = string
+  description = "The gateway of the VM."
+  default     = null
+}
+
+variable "vm_ip_netmask" {
+  type        = number
+  description = "The netmask of the VM."
+  default     = null
+}
+
+variable "vm_dns_list" {
+  type        = list(string)
+  description = "The DNS servers of the VM."
+  default     = []
+}
+
+variable "vm_mem_size" {
+  type        = number
+  description = "The size for the virtual memory in MB."
+  default     = 4096
+}
+
+variable "vm_network_card_model" {
+  type        = string
+  description = "The virtual network adapter to emulate."
+  default     = "virtio-net"
+}
+
+variable "vm_network_device" {
+  type        = string
+  description = "The network device name configured inside NixOS."
+  default     = "eth0"
+}
+
+variable "vm_os_name" {
+  type        = string
+  description = "The guest operating system name."
+  default     = "nixos"
+}
+
+variable "vm_os_version" {
+  type        = string
+  description = "The guest operating system version."
+  default     = "25.11"
+}

--- a/validate.sh
+++ b/validate.sh
@@ -23,6 +23,7 @@ INPUT_PATHS=(
   "$SCRIPT_PATH/builds/linux/centos/9-stream/"
   "$SCRIPT_PATH/builds/linux/debian/12/"
   "$SCRIPT_PATH/builds/linux/debian/11/"
+  "$SCRIPT_PATH/builds/linux/nixos/25.11/"
   "$SCRIPT_PATH/builds/linux/opensuse/leap-15-6/"
   "$SCRIPT_PATH/builds/linux/opensuse/leap-15-5/"
   "$SCRIPT_PATH/builds/linux/oracle/9/"


### PR DESCRIPTION
## Summary
- Add NixOS 25.11 Packer target for Proxmox (menu option 22)
- Add local QEMU smoke test for iterating on NixOS installer
- Preserve QEMU test serial logs on failure
- Update .gitignore to exclude .specstory directory
- Update README with NixOS QEMU testing documentation

## Changes
- **New Build Template**: NixOS 25.11 available as option 22 in build menu
- **Testing**: Local QEMU smoke test under \	ests/nixos-qemu/\ for rapid iteration
- **Documentation**: Updated README with NixOS QEMU test instructions
- **Maintenance**: Added .specstory/ to .gitignore

## Test plan
- [ ] Verify NixOS 25.11 builds successfully in Proxmox using option 22
- [ ] Run local QEMU smoke test: \./tests/nixos-qemu/run.sh\
- [ ] Check that serial logs are preserved on test failure
- [ ] Verify Ubuntu 26.04 still works as option 21